### PR TITLE
Batch Generation Improvements

### DIFF
--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioBatchActor.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioBatchActor.cpp
@@ -302,6 +302,7 @@ void AVitruvioBatchActor::ProcessGenerateQueue()
 		{
 			UVitruvioComponent* VitruvioComponent = Item.VitruvioComponents[ComponentIndex];
 			Item.GenerateResultDescription.EvaluatedAttributes[ComponentIndex]->UpdateUnrealAttributeMap(VitruvioComponent->Attributes, VitruvioComponent);
+			VitruvioComponent->bAttributesReady = true;
 			VitruvioComponent->NotifyAttributesChanged();
 		}
 

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioBatchActor.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioBatchActor.cpp
@@ -261,8 +261,13 @@ void AVitruvioBatchActor::ProcessTiles()
 			Tile->bIsGenerating = true;
 		
 			// clang-format off
-			GenerateResult.Result.Next([this, Tile, InitialShapeVitruvioComponents](const FBatchGenerateResult::ResultType& Result)
+			GenerateResult.Result.Next([WeakThis = MakeWeakObjectPtr(this), Tile, InitialShapeVitruvioComponents](const FBatchGenerateResult::ResultType& Result)
 			{
+				if (!WeakThis.IsValid())
+				{
+					return;
+				}
+				
 				FScopeLock Lock(&Result.Token->Lock);
 
 				if (Result.Token->IsInvalid())
@@ -272,8 +277,8 @@ void AVitruvioBatchActor::ProcessTiles()
 
 				Tile->GenerateToken.Reset();
 
-				FScopeLock GenerateQueueLock(&ProcessQueueCriticalSection);
-				GenerateQueue.Enqueue({Result.Value, Tile, InitialShapeVitruvioComponents});
+				FScopeLock GenerateQueueLock(&WeakThis->ProcessQueueCriticalSection);
+				WeakThis->GenerateQueue.Enqueue({Result.Value, Tile, InitialShapeVitruvioComponents});
 			});
 			// clang-format on
 		}

--- a/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
+++ b/VitruvioHost/Plugins/Vitruvio/Source/Vitruvio/Private/VitruvioComponent.cpp
@@ -141,7 +141,12 @@ void SetAttribute(UVitruvioComponent* VitruvioComponent, const TMap<FString, URu
 
 	TAttribute->bUserSet = true;
 
-	if (bEvaluateAttributes || bGenerateModel)
+	if (bGenerateModel && VitruvioComponent->IsBatchGenerated())
+	{
+		VitruvioComponent->Generate(CallbackProxy);
+	}
+
+	if (bEvaluateAttributes)
 	{
 		VitruvioComponent->EvaluateRuleAttributes(bGenerateModel, CallbackProxy);
 	}
@@ -240,7 +245,14 @@ void EvaluateAndSetAttributes(UVitruvioComponent* VitruvioComponent, const TMap<
 			}
 		}
 
-		VitruvioComponent->EvaluateRuleAttributes(bGenerateModel, CallbackProxy);
+		if (bGenerateModel && VitruvioComponent->IsBatchGenerated())
+		{
+			VitruvioComponent->Generate(CallbackProxy);
+		}
+		else
+		{
+			VitruvioComponent->EvaluateRuleAttributes(bGenerateModel, CallbackProxy);
+		}
 	}
 }
 


### PR DESCRIPTION
- Fix possible null rerefernce when the level is unloaded before the batch generation has completed
- Also mark attributes on VitruvioComponents as ready when they are evaluated from the batch generation (which also evaluates attributes)
- Forward the evaluation of attributes to the batch generation when attributes values are changed on the VitruvioComponent